### PR TITLE
Issue #3101277: Thunder 3.4 tests are failing with simple_sitemap 3.5

### DIFF
--- a/tests/src/FunctionalJavascript/MetaInformationTest.php
+++ b/tests/src/FunctionalJavascript/MetaInformationTest.php
@@ -369,7 +369,7 @@ class MetaInformationTest extends ThunderJavascriptTestBase {
 
     // After sitemap.xml -> we have to open page without setting cookie before.
     $this->getSession()
-      ->visit($this->buildUrl('admin/config/search/simplesitemap'));
+      ->visit($this->buildUrl('admin/config/search/simplesitemap/settings'));
     $page = $this->getSession()->getPage();
     $this->setFieldValues($page, [
       'max_links' => '2',


### PR DESCRIPTION
There is a new release of simple sitemap. They have reorganized admin pages a bit.
