### PR TITLE
Issue #3101277: Thunder 3.4 tests are failing with simple_sitemap 3.5 (fix composer min tests)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -124,7 +124,7 @@
         "drupal/media_expire": "^2.2",
         "drupal/metatag": "^1.9",
         "drupal/paragraphs": "^1.9",
-        "drupal/paragraphs_features": "^1.0",
+        "drupal/paragraphs_features": "^1.7",
         "drupal/password_policy": "3.0-alpha5",
         "drupal/pathauto": "^1.6",
         "drupal/responsive_preview": "^1.0-alpha7",

--- a/tests/src/FunctionalJavascript/MetaInformationTest.php
+++ b/tests/src/FunctionalJavascript/MetaInformationTest.php
@@ -368,14 +368,7 @@ class MetaInformationTest extends ThunderJavascriptTestBase {
     $this->assertEquals('0.9', $domElements->item(0)->nodeValue);
 
     // After sitemap.xml -> we have to open page without setting cookie before.
-    $this->getSession()
-      ->visit($this->buildUrl('admin/config/search/simplesitemap/settings'));
-    $page = $this->getSession()->getPage();
-    $this->setFieldValues($page, [
-      'max_links' => '2',
-    ]);
-    $page->find('xpath', '//input[@id="edit-submit"]')->click();
-
+    $this->container->get('config.factory')->getEditable('simple_sitemap.settings')->set('max_links', 2)->save();
     $this->sitemapGenerator->generateSitemap('backend');
 
     // Check loc, that it's pointing to sitemap.xml file.


### PR DESCRIPTION
Cherry pick from #122 

- Update of paragraphs features min version for composer min build
- Change to configuration update instead using of Admin UI in test
