### PR TITLE
Fix finish_url so it does not cause a redirect

### DIFF
--- a/thunder.info.yml
+++ b/thunder.info.yml
@@ -9,7 +9,7 @@ distribution:
   name: Thunder
   install:
     theme: thunder_admin
-    finish_url: /?tour=1
+    finish_url: ?tour=1
 
 # Required modules
 dependencies:


### PR DESCRIPTION
The `install_goto()` function adds a leading / so our finish_url will result in leading slashes which will cause the \Drupal\Core\EventSubscriber\RedirectLeadingSlashesSubscriber to kick in.

```
function install_goto($path) {
  global $base_url;
  $headers = [
    // Not a permanent redirect.
    'Cache-Control' => 'no-cache',
  ];
  $response = new RedirectResponse($base_url . '/' . $path, 302, $headers);
  $response->send();
}
```

Make sure these boxes are checked before submitting your pull request - thank you!

- [ ] All coding styles are fulfilled. ([How to check for cs issues?](https://github.com/BurdaMagazinOrg/thunder-dev-tools/blob/master/README.md#code-style-guidelines))
- [ ] All tests are running locally. ([How to run the test?](https://github.com/thunder/thunder-distribution/blob/8.x-4.x/docs/development.md#how-to-run-the-tests))
- [ ] Necessary update hooks are provided.
- [ ] User roles have correct access for new introduced permission.
- [ ] Every thunder module has a README.md in its root. Follow [this guidelines](https://www.drupal.org/node/2181737), but we don't need every topic.
- [ ] Code is covered with well-balanced amount of inline comments.

If you are really awesome, then your feature is covered by additional tests. Well done!
