### PR TITLE
Allow users with 'delete any file' permission to delete files when deleting media entities

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -96,6 +96,7 @@
         "drupal/media_entity_slideshow": "^2.0-alpha1",
         "drupal/media_entity_twitter": "^2.5",
         "drupal/media_expire": "^2.4",
+        "drupal/media_file_delete": "^1.2",
         "drupal/metatag": "^1.19",
         "drupal/metatag_async_widget": "^1.0-alpha2",
         "drupal/paragraphs": "^1.12",

--- a/modules/thunder_media/thunder_media.module
+++ b/modules/thunder_media/thunder_media.module
@@ -188,7 +188,7 @@ function _thunder_media_media_field_widget_form_alter_helper(array &$widget, str
  *   in Drupal core and the version it lands in is the minimum supported
  *   version.
  */
-function thunder_media_file_access(FileInterface $file, $op, AccountInterface $account) {
+function thunder_media_file_access(FileInterface $file, string $op, AccountInterface $account): AccessResult {
   switch ($op) {
     case 'delete':
       $access = AccessResult::allowedIfHasPermission($account, 'delete any file');

--- a/modules/thunder_media/thunder_media.module
+++ b/modules/thunder_media/thunder_media.module
@@ -5,7 +5,10 @@
  * Contains media related functions.
  */
 
+use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\file\FileInterface;
 
 /**
  * Implements hook_preprocess_media().
@@ -176,4 +179,23 @@ function _thunder_media_media_field_widget_form_alter_helper(array &$widget, str
       }
     }
   }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_access().
+ *
+ * @todo Remove when https://www.drupal.org/project/drupal/issues/2949017 lands
+ *   in Drupal core and the version it lands in is the minimum supported
+ *   version.
+ */
+function thunder_media_file_access(FileInterface $file, $op, AccountInterface $account) {
+  switch ($op) {
+    case 'delete':
+      $access = AccessResult::allowedIfHasPermission($account, 'delete any file');
+      break;
+
+    default:
+      $access = AccessResult::neutral();
+  }
+  return $access;
 }

--- a/modules/thunder_media/thunder_media.permissions.yml
+++ b/modules/thunder_media/thunder_media.permissions.yml
@@ -1,0 +1,4 @@
+# Match permission with https://www.drupal.org/project/drupal/issues/2949017
+delete any file:
+  title: 'Delete any file'
+  restrict access: true

--- a/tests/src/FunctionalJavascript/MediaImageModifyTest.php
+++ b/tests/src/FunctionalJavascript/MediaImageModifyTest.php
@@ -100,8 +100,7 @@ class MediaImageModifyTest extends ThunderJavascriptTestBase {
     // Go to the media view and try deleting the image media.
     $this->drupalGet('admin/content/media');
     $this->getSession()->getPage()->find('css', 'div.view-media')->clickLink('Thunder City');
-    /** @var \Drupal\media\Entity\Media $media */
-    $media = \Drupal::service('entity.repository')->loadEntityByUuid('media', '5d719c64-7f32-4062-9967-9874f5ca3eba');
+    $media = $this->loadMediaByUuid('5d719c64-7f32-4062-9967-9874f5ca3eba');
     $this->assertSession()->addressMatches('#media/' . $media->id() . '/edit$#');
     /** @var \Drupal\file\FileInterface $file */
     $file = $media->get($media->getSource()->getConfiguration()['source_field'])->entity;

--- a/tests/src/FunctionalJavascript/MediaImageModifyTest.php
+++ b/tests/src/FunctionalJavascript/MediaImageModifyTest.php
@@ -6,8 +6,6 @@ use Drupal\file\Entity\File;
 use Drupal\image\Entity\ImageStyle;
 use Drupal\media\Entity\Media;
 use Drupal\user\Entity\Role;
-use Rector\TypeDeclaration\TypeInferer\VarDocPropertyTypeInferer;
-use Symfony\Component\VarDumper\VarDumper;
 
 /**
  * Tests the Image media modification.

--- a/tests/src/FunctionalJavascript/MediaImageModifyTest.php
+++ b/tests/src/FunctionalJavascript/MediaImageModifyTest.php
@@ -4,7 +4,6 @@ namespace Drupal\Tests\thunder\FunctionalJavascript;
 
 use Drupal\file\Entity\File;
 use Drupal\image\Entity\ImageStyle;
-use Drupal\media\Entity\Media;
 use Drupal\user\Entity\Role;
 
 /**
@@ -101,8 +100,9 @@ class MediaImageModifyTest extends ThunderJavascriptTestBase {
     // Go to the media view and try deleting the image media.
     $this->drupalGet('admin/content/media');
     $this->getSession()->getPage()->find('css', 'div.view-media')->clickLink('Thunder City');
-    $this->assertSession()->addressMatches('#media/5/edit$#');
-    $media = Media::load(5);
+    /** @var \Drupal\media\Entity\Media $media */
+    $media = \Drupal::service('entity.repository')->loadEntityByUuid('media', '5d719c64-7f32-4062-9967-9874f5ca3eba');
+    $this->assertSession()->addressMatches('#media/' . $media->id() . '/edit$#');
     /** @var \Drupal\file\FileInterface $file */
     $file = $media->get($media->getSource()->getConfiguration()['source_field'])->entity;
     $this->assertFileExists($file->getFileUri());

--- a/tests/src/FunctionalJavascript/MediaImageModifyTest.php
+++ b/tests/src/FunctionalJavascript/MediaImageModifyTest.php
@@ -4,6 +4,10 @@ namespace Drupal\Tests\thunder\FunctionalJavascript;
 
 use Drupal\file\Entity\File;
 use Drupal\image\Entity\ImageStyle;
+use Drupal\media\Entity\Media;
+use Drupal\user\Entity\Role;
+use Rector\TypeDeclaration\TypeInferer\VarDocPropertyTypeInferer;
+use Symfony\Component\VarDumper\VarDumper;
 
 /**
  * Tests the Image media modification.
@@ -95,6 +99,23 @@ class MediaImageModifyTest extends ThunderJavascriptTestBase {
     $this->clickAjaxButtonCssSelector('[name="field_paragraphs_0_collapse"]');
 
     $this->assertEquals($fileName, $this->getSession()->evaluateScript('jQuery(\'[data-drupal-selector="edit-field-paragraphs-0-preview"] div.paragraph-preview__thumbnail img\').attr(\'src\').split(\'?\')[0].split(\'/\').splice(-1)'), 'Image file should be identical to previously selected.');
+
+    // Go to the media view and try deleting the image media.
+    $this->drupalGet('admin/content/media');
+    $this->getSession()->getPage()->find('css', 'div.view-media')->clickLink('Thunder City');
+    $this->assertSession()->addressMatches('#media/5/edit$#');
+    $media = Media::load(5);
+    /** @var \Drupal\file\FileInterface $file */
+    $file = $media->get($media->getSource()->getConfiguration()['source_field'])->entity;
+    $this->assertFileExists($file->getFileUri());
+    $this->getSession()->getPage()->find('css', 'div.block-local-tasks-block')->clickLink('Delete');
+    $this->assertSession()->fieldNotExists('also_delete_file');
+    $this->assertSession()->pageTextContains('This action cannot be undone. The file attached to this media is owned by admin so will be retained.');
+    Role::load(static::$defaultUserRole)->grantPermission('delete any file')->save();
+    $this->getSession()->reload();
+    $this->assertSession()->fieldExists('also_delete_file')->check();
+    $this->getSession()->getPage()->pressButton('Delete');
+    $this->assertFileDoesNotExist($file->getFileUri());
   }
 
 }

--- a/thunder.info.yml
+++ b/thunder.info.yml
@@ -66,6 +66,7 @@ install:
   - media_entity_slideshow:media_entity_slideshow
   - media_entity_twitter:media_entity_twitter
   - media_expire:media_expire
+  - media_file_delete:media_file_delete
   - metatag:metatag
   - metatag:metatag_open_graph
   - metatag:metatag_facebook

--- a/thunder.install
+++ b/thunder.install
@@ -335,3 +335,12 @@ function thunder_update_8325(): string {
   // Output logged messages to related channel of update execution.
   return $updater->logger()->output();
 }
+
+/**
+ * Install media_file_delete.
+ */
+function thunder_update_8326(): void {
+  /** @var \Drupal\Core\Extension\ModuleInstallerInterface $moduleInstaller */
+  $moduleInstaller = \Drupal::service('module_installer');
+  $moduleInstaller->install(['media_file_delete']);
+}


### PR DESCRIPTION
Make sure these boxes are checked before submitting your pull request - thank you!

- [x] All coding styles are fulfilled. ([How to check for cs issues?](https://github.com/BurdaMagazinOrg/thunder-dev-tools/blob/master/README.md#code-style-guidelines))
- [x] All tests are running locally. ([How to run the test?](https://github.com/thunder/thunder-distribution/blob/8.x-4.x/docs/development.md#how-to-run-the-tests))
- [x] Necessary update hooks are provided.
- [x] User roles have correct access for new introduced permission.
- [x] Every thunder module has a README.md in its root. Follow [this guidelines](https://www.drupal.org/node/2181737), but we don't need every topic.
- [x] Code is covered with well-balanced amount of inline comments.
- [x] New features or changes are documented.

If you are really awesome, then your feature is covered by additional tests. Well done!
