### PR TITLE
upgrade to google_analytics 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
         "drupal/field_group": "^3.4",
         "drupal/focal_point": "^1.3",
         "drupal/facets": "^2.0",
-        "drupal/google_analytics": "^2.0",
+        "drupal/google_analytics": "^4.0",
         "drupal/graphql": "^4.3",
         "drupal/inline_entity_form": "^1.0-rc7",
         "drupal/ivw_integration": "^2.0",


### PR DESCRIPTION
Upgrade google analytics to the supported 4.x version. 4.x improves compatibility with the new google analytics standard coming out as well as PHP 8.1 compliance.


Make sure these boxes are checked before submitting your pull request - thank you!

- [ ] All coding styles are fulfilled. ([How to check for cs issues?](https://github.com/BurdaMagazinOrg/thunder-dev-tools/blob/master/README.md#code-style-guidelines))
- [ ] All tests are running locally. ([How to run the test?](https://github.com/thunder/thunder-distribution/blob/8.x-4.x/docs/development.md#how-to-run-the-tests))
- [ ] Necessary update hooks are provided.
- [ ] User roles have correct access for new introduced permission.
- [ ] Every thunder module has a README.md in its root. Follow [this guidelines](https://www.drupal.org/node/2181737), but we don't need every topic.
- [ ] Code is covered with well-balanced amount of inline comments.
- [ ] New features or changes are documented.

If you are really awesome, then your feature is covered by additional tests. Well done!
