### PR TITLE
Add src field to ParagraphVideo type

### DIFF
--- a/modules/thunder_gqls/graphql/thunder_paragraphs.base.graphqls
+++ b/modules/thunder_gqls/graphql/thunder_paragraphs.base.graphqls
@@ -54,6 +54,7 @@ type ParagraphVideo implements Paragraph {
   provider: String
   url: String
   video: MediaVideo
+  src: String
 }
 
 type ParagraphQuote implements Paragraph {

--- a/modules/thunder_gqls/graphql/thunder_paragraphs.base.graphqls
+++ b/modules/thunder_gqls/graphql/thunder_paragraphs.base.graphqls
@@ -54,7 +54,7 @@ type ParagraphVideo implements Paragraph {
   provider: String
   url: String
   video: MediaVideo
-  src: String
+  reference: String
 }
 
 type ParagraphQuote implements Paragraph {

--- a/modules/thunder_gqls/src/Plugin/GraphQL/DataProducer/MediaSourceField.php
+++ b/modules/thunder_gqls/src/Plugin/GraphQL/DataProducer/MediaSourceField.php
@@ -34,7 +34,7 @@ class MediaSourceField extends DataProducerPluginBase {
    *   The source field value.
    */
   public function resolve(MediaInterface $media): string {
-    return strtolower($media->getSource()->getSourceFieldValue($media)) ?: '';
+    return $media->getSource()->getSourceFieldValue($media) ?: '';
   }
 
 }

--- a/modules/thunder_gqls/src/Plugin/GraphQL/DataProducer/MediaSourceField.php
+++ b/modules/thunder_gqls/src/Plugin/GraphQL/DataProducer/MediaSourceField.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\thunder_gqls\Plugin\GraphQL\DataProducer;
+
+use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
+use Drupal\media\MediaInterface;
+
+/**
+ * Resolves the source field of a media entity.
+ *
+ * @DataProducer(
+ *   id = "media_source_field",
+ *   name = @Translation("MediaSourceField"),
+ *   description = @Translation("Resolves the source field of a media entity."),
+ *   produces = @ContextDefinition("string",
+ *     label = @Translation("The source field")
+ *   ),
+ *   consumes = {
+ *     "media" = @ContextDefinition("entity",
+ *       label = @Translation("Root value")
+ *     )
+ *   }
+ * )
+ */
+class MediaSourceField extends DataProducerPluginBase {
+
+  /**
+   * Resolves the source field of a media entity.
+   *
+   * @param \Drupal\media\MediaInterface $media
+   *   The media entity.
+   *
+   * @return string
+   *   The source field value.
+   */
+  public function resolve(MediaInterface $media): string {
+    return strtolower($media->getSource()->getSourceFieldValue($media)) ?: '';
+  }
+
+}

--- a/modules/thunder_gqls/src/Plugin/GraphQL/DataProducer/ThunderMediaProvider.php
+++ b/modules/thunder_gqls/src/Plugin/GraphQL/DataProducer/ThunderMediaProvider.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\thunder_gqls\Plugin\GraphQL\DataProducer;
+
+use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
+use Drupal\media\MediaInterface;
+
+/**
+ * Resolves the provider of a media oEmbed entity or the source ID.
+ *
+ * @DataProducer(
+ *   id = "thunder_media_provider",
+ *   name = @Translation("ThuderMediaProvider"),
+ *   description = @Translation("Resolves the provider of a media oEmbed entity or the source ID."),
+ *   produces = @ContextDefinition("string",
+ *     label = @Translation("The provider")
+ *   ),
+ *   consumes = {
+ *     "media" = @ContextDefinition("entity",
+ *       label = @Translation("Root value")
+ *     )
+ *   }
+ * )
+ */
+class ThunderMediaProvider extends DataProducerPluginBase {
+
+  /**
+   * Resolves the provider of a media oEmbed entity or the source ID.
+   *
+   * @param \Drupal\media\MediaInterface $media
+   *   The media entity.
+   *
+   * @return string
+   *   The provider.
+   */
+  public function resolve(MediaInterface $media): string {
+    return strtolower($media->getSource()->getMetadata($media, 'provider_name') ?: $media->getSource()->getPluginId()) ?: '';
+  }
+
+}

--- a/modules/thunder_gqls/src/Plugin/GraphQL/SchemaExtension/ThunderMediaSchemaExtension.php
+++ b/modules/thunder_gqls/src/Plugin/GraphQL/SchemaExtension/ThunderMediaSchemaExtension.php
@@ -108,7 +108,7 @@ class ThunderMediaSchemaExtension extends ThunderSchemaExtensionPluginBase {
     $this->resolveMediaInterfaceFields('MediaVideo');
 
     $this->addFieldResolverIfNotExists('MediaVideo', 'src',
-      $this->builder->fromPath('entity', 'field_media_video_embed_field.value')
+      $this->builder->produce('media_source_field')->map('media', $this->builder->fromParent())
     );
 
     $this->addFieldResolverIfNotExists('MediaVideo', 'username',

--- a/modules/thunder_gqls/src/Plugin/GraphQL/SchemaExtension/ThunderParagraphsSchemaExtension.php
+++ b/modules/thunder_gqls/src/Plugin/GraphQL/SchemaExtension/ThunderParagraphsSchemaExtension.php
@@ -110,12 +110,19 @@ class ThunderParagraphsSchemaExtension extends ThunderSchemaExtensionPluginBase 
     $this->addFieldResolverIfNotExists('ParagraphVideo', 'provider',
       $this->builder->compose(
         $this->builder->fromPath('entity', 'field_video.entity'),
-        $this->builder->produce('oembed_media_provider')
+        $this->builder->produce('thunder_media_provider')
           ->map('media', $this->builder->fromParent())
       )
     );
     $this->addFieldResolverIfNotExists('ParagraphVideo', 'url',
       $this->builder->fromPath('entity', 'field_video.entity.field_media_video_embed_field.value'),
+    );
+    $this->addFieldResolverIfNotExists('ParagraphVideo', 'src',
+      $this->builder->compose(
+        $this->builder->fromPath('entity', 'field_video.entity'),
+        $this->builder->produce('media_source_field')
+          ->map('media', $this->builder->fromParent())
+      )
     );
 
     // Quote.

--- a/modules/thunder_gqls/src/Plugin/GraphQL/SchemaExtension/ThunderParagraphsSchemaExtension.php
+++ b/modules/thunder_gqls/src/Plugin/GraphQL/SchemaExtension/ThunderParagraphsSchemaExtension.php
@@ -117,7 +117,7 @@ class ThunderParagraphsSchemaExtension extends ThunderSchemaExtensionPluginBase 
     $this->addFieldResolverIfNotExists('ParagraphVideo', 'url',
       $this->builder->fromPath('entity', 'field_video.entity.field_media_video_embed_field.value'),
     );
-    $this->addFieldResolverIfNotExists('ParagraphVideo', 'src',
+    $this->addFieldResolverIfNotExists('ParagraphVideo', 'reference',
       $this->builder->compose(
         $this->builder->fromPath('entity', 'field_video.entity'),
         $this->builder->produce('media_source_field')

--- a/modules/thunder_gqls/tests/examples/paragraphs.query.graphql
+++ b/modules/thunder_gqls/tests/examples/paragraphs.query.graphql
@@ -28,6 +28,7 @@ query ($path: String!) {
         ... on ParagraphVideo {
           url
           provider
+          src
         }
         ... on ParagraphPinterest {
           url

--- a/modules/thunder_gqls/tests/examples/paragraphs.query.graphql
+++ b/modules/thunder_gqls/tests/examples/paragraphs.query.graphql
@@ -28,7 +28,7 @@ query ($path: String!) {
         ... on ParagraphVideo {
           url
           provider
-          src
+          reference
         }
         ... on ParagraphPinterest {
           url

--- a/modules/thunder_gqls/tests/examples/paragraphs.response.json
+++ b/modules/thunder_gqls/tests/examples/paragraphs.response.json
@@ -61,7 +61,7 @@
           "__typename": "ParagraphVideo",
           "url": "https://www.youtube.com/watch?v=Hu5hC46z5LI",
           "provider": "youtube",
-          "src": "https://www.youtube.com/watch?v=Hu5hC46z5LI"
+          "src": "https://www.youtube.com/watch?v=hu5hc46z5li"
         },
         {
           "__typename": "ParagraphPinterest",

--- a/modules/thunder_gqls/tests/examples/paragraphs.response.json
+++ b/modules/thunder_gqls/tests/examples/paragraphs.response.json
@@ -61,7 +61,7 @@
           "__typename": "ParagraphVideo",
           "url": "https://www.youtube.com/watch?v=Hu5hC46z5LI",
           "provider": "youtube",
-          "src": "https://www.youtube.com/watch?v=hu5hc46z5li"
+          "src": "https://www.youtube.com/watch?v=Hu5hC46z5LI"
         },
         {
           "__typename": "ParagraphPinterest",

--- a/modules/thunder_gqls/tests/examples/paragraphs.response.json
+++ b/modules/thunder_gqls/tests/examples/paragraphs.response.json
@@ -61,7 +61,7 @@
           "__typename": "ParagraphVideo",
           "url": "https://www.youtube.com/watch?v=Hu5hC46z5LI",
           "provider": "youtube",
-          "src": "https://www.youtube.com/watch?v=Hu5hC46z5LI"
+          "reference": "https://www.youtube.com/watch?v=Hu5hC46z5LI"
         },
         {
           "__typename": "ParagraphPinterest",

--- a/modules/thunder_gqls/tests/examples/paragraphs.response.json
+++ b/modules/thunder_gqls/tests/examples/paragraphs.response.json
@@ -60,7 +60,8 @@
         {
           "__typename": "ParagraphVideo",
           "url": "https://www.youtube.com/watch?v=Hu5hC46z5LI",
-          "provider": "youtube"
+          "provider": "youtube",
+          "src": "https://www.youtube.com/watch?v=Hu5hC46z5LI"
         },
         {
           "__typename": "ParagraphPinterest",


### PR DESCRIPTION
- feat(thunder_gqls): add MediaSourceField data producer plugin for GraphQL
- feat(thunder_gqls): add ThunderMediaProvider data producer plugin
- fix(thunder_gqls): fix MediaVideo src field resolver to use media_source_field data producer plugin
- feat(thunder_gqls): add src field resolver for ParagraphVideo GraphQL type
- test(thunder_gqls): update paragraphs.query.graphql and paragraphs.response.json to include src field for ParagraphVideo type

Make sure these boxes are checked before submitting your pull request - thank you!

- [ ] All coding styles are fulfilled. ([How to check for cs issues?](https://github.com/BurdaMagazinOrg/thunder-dev-tools/blob/master/README.md#code-style-guidelines))
- [ ] All tests are running locally. ([How to run the test?](https://github.com/thunder/thunder-distribution/blob/8.x-4.x/docs/development.md#how-to-run-the-tests))
- [ ] Necessary update hooks are provided.
- [ ] User roles have correct access for new introduced permission.
- [ ] Every thunder module has a README.md in its root. Follow [this guidelines](https://www.drupal.org/node/2181737), but we don't need every topic.
- [ ] Code is covered with well-balanced amount of inline comments.
- [ ] New features or changes are documented.

If you are really awesome, then your feature is covered by additional tests. Well done!
