### PR TITLE
feat: add configurable quick links to ThunderParagraphsTestTrait

### DIFF
--- a/tests/src/FunctionalJavascript/ThunderParagraphsTestTrait.php
+++ b/tests/src/FunctionalJavascript/ThunderParagraphsTestTrait.php
@@ -16,6 +16,32 @@ trait ThunderParagraphsTestTrait {
   use ThunderCkEditorTestTrait;
 
   /**
+   * @var int[]
+   */
+  protected array $thunderQuickLinksAddParagraphTypes = [
+    'text' => 1,
+    'image' => 2,
+    'gallery' => 3,
+  ];
+
+  /**
+   * @return int[]
+   */
+  public function getThunderQuickLinksAddParagraphTypes(): array {
+    return $this->thunderQuickLinksAddParagraphTypes;
+  }
+
+  /**
+   * @param array $types
+   *
+   * @return self
+   */
+  public function setThunderQuickLinksAddParagraphTypes(array $types): self {
+    $this->thunderQuickLinksAddParagraphTypes = $types;
+    return $this;
+  }
+
+  /**
    * Get number of paragraphs for defined field on current page.
    *
    * @param string $fieldName
@@ -54,21 +80,24 @@ trait ThunderParagraphsTestTrait {
    *   Field name.
    * @param string $type
    *   Type of the paragraph.
-   * @param int $position
-   *   Position of the paragraph.
+   * @param int|null $position
+   *   Position of the paragraph (default: null).
    *
    * @return int
    *   Returns index for added paragraph.
    *
    * @throws \Exception
+   * @throws \Behat\Mink\Exception\DriverException
+   * @throws \Behat\Mink\Exception\UnsupportedDriverActionException
    */
-  public function addParagraph(string $fieldName, string $type, $position = NULL) {
+  public function addParagraph(string $fieldName, string $type, ?int $position = NULL): int {
     $numberOfParagraphs = $this->getNumberOfParagraphs($fieldName);
 
-    $types = ['text' => 1, 'image' => 2, 'gallery' => 3];
-    $index = $types[$type] ?? 4;
+    $types = $this->getThunderQuickLinksAddParagraphTypes();
+    $index = $types[$type] ?? count($types) + 1;
 
     $fieldSelector = HTML::cleanCssIdentifier($fieldName);
+
     if ($position === NULL || $position > $numberOfParagraphs) {
       $position = $numberOfParagraphs;
       $addButtonCssSelector = "#edit-{$fieldSelector}-wrapper table > tbody > tr:last-child li:nth-child({$index}) button.paragraphs-features__add-in-between__button";


### PR DESCRIPTION
Current implementation of ThunderParagraphsTestTrait does only provide Thunder's default paragraphs form configuration with fixed amount and types of paragraphs quick links.

With this little change projects could also use ThunderParagraphsTestTrait with other amount and types of paragraphs quick links in own paragraph form testing.

Comments to get PHPCS green are missing yet. Will be added, when general idea is fine for all.

I think it will be no breaking change for other projects which already relies on ThunderParagraphsTestTrait in their tests.

Needs to be ported to 7.0.x when it is not already improved in new default branch.

Make sure these boxes are checked before submitting your pull request - thank you!

- [ ] All coding styles are fulfilled. ([How to check for cs issues?](https://github.com/BurdaMagazinOrg/thunder-dev-tools/blob/master/README.md#code-style-guidelines))
- [ ] All tests are running locally. ([How to run the test?](https://github.com/thunder/thunder-distribution/blob/8.x-4.x/docs/development.md#how-to-run-the-tests))
- [ ] Necessary update hooks are provided.
- [ ] User roles have correct access for new introduced permission.
- [ ] Every thunder module has a README.md in its root. Follow [this guidelines](https://www.drupal.org/node/2181737), but we don't need every topic.
- [ ] Code is covered with well-balanced amount of inline comments.
- [ ] New features or changes are documented.

If you are really awesome, then your feature is covered by additional tests. Well done!
