### PR TITLE
Add schema for thunder graphql schema plugin settings so that extensions can be ordered by key

### DIFF
--- a/modules/thunder_gqls/config/schema/thunder_gqls.schema.yml
+++ b/modules/thunder_gqls/config/schema/thunder_gqls.schema.yml
@@ -1,0 +1,14 @@
+graphql.schema.thunder:
+  type: mapping
+  label: 'Thunder schema'
+  mapping:
+    thunder:
+      type: mapping
+      label: 'Composition'
+      mapping:
+        extensions:
+          label: Enabled extensions
+          type: sequence
+          orderby: key
+          sequence:
+            type: string


### PR DESCRIPTION
This adds a schema for thunder_gqls so that extensions can be ordered by key on config export. This makes merging and other vcs related operations easier and more predictable.