### PR TITLE
Add ThunderPromptSource: ai_prompt_content-backed prompt source seam

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -134,6 +134,7 @@
     "require-dev": {
         "burdamagazinorg/thunder-dev-tools": "dev-master",
         "thunder/thunder_testing_demo": "4.x-dev",
+        "drupal/ai_chatbot_assistant_ui": "1.0.x-dev",
         "mglaman/phpstan-drupal": "^2.0",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpunit/phpunit": "^11.5"

--- a/modules/thunder_ai_prompt_management/src/ThunderAiPromptManagementServiceProvider.php
+++ b/modules/thunder_ai_prompt_management/src/ThunderAiPromptManagementServiceProvider.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\thunder_ai_prompt_management;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceModifierInterface;
+
+/**
+ * Swaps ai_chatbot_assistant_ui.prompt_source for ThunderPromptSource.
+ *
+ * Via alter(), not a services.yml override, to avoid a hard dependency.
+ */
+class ThunderAiPromptManagementServiceProvider implements ServiceModifierInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alter(ContainerBuilder $container): void {
+    if ($container->hasDefinition('ai_chatbot_assistant_ui.prompt_source')) {
+      // The definition already carries autowire: true, so re-classing it is
+      // enough - ThunderPromptSource's own constructor gets autowired.
+      $container->getDefinition('ai_chatbot_assistant_ui.prompt_source')
+        ->setClass(ThunderPromptSource::class);
+    }
+  }
+
+}

--- a/modules/thunder_ai_prompt_management/src/ThunderPromptSource.php
+++ b/modules/thunder_ai_prompt_management/src/ThunderPromptSource.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\thunder_ai_prompt_management;
+
+use Drupal\ai_chatbot_assistant_ui\PromptSourceInterface;
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\thunder_ai_prompt_management\Entity\AIPrompt;
+
+/**
+ * Prompt source backed by ai_prompt_content, grouped by ai_task.
+ */
+final class ThunderPromptSource implements PromptSourceInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * Group id for prompts whose ai_task is unset.
+   */
+  private const UNGROUPED = '_none';
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+  ) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getSlashGroups(?string $entityType, ?string $bundle, CacheableMetadata $cacheability): array {
+    $cacheability->addCacheTags($this->entityTypeManager->getStorage('ai_task')->getEntityType()->getListCacheTags());
+    $cacheability->addCacheTags($this->entityTypeManager->getStorage('ai_prompt_content')->getEntityType()->getListCacheTags());
+
+    $by_task = [];
+    foreach ($this->publishedPrompts() as $prompt) {
+      if (!$this->matchesContext($prompt, $entityType, $bundle)) {
+        continue;
+      }
+      $cacheability->addCacheableDependency($prompt);
+      $task = $prompt->get('ai_task')->entity;
+      // ai_task is optional, so an unassigned prompt still needs a group.
+      $task_id = $task !== NULL ? $task->id() : self::UNGROUPED;
+      $by_task[$task_id][] = [
+        'id' => (string) $prompt->id(),
+        'label' => $prompt->label(),
+        'description' => '',
+        'prompt' => (string) $prompt->get('prompt')->value,
+      ];
+    }
+
+    $groups = [];
+    foreach ($by_task as $task_id => $prompts) {
+      if ($task_id === self::UNGROUPED) {
+        $label = $this->t('Prompts');
+      }
+      else {
+        $task = $this->entityTypeManager->getStorage('ai_task')->load($task_id);
+        if ($task === NULL) {
+          continue;
+        }
+        $cacheability->addCacheableDependency($task);
+        $label = $task->label();
+      }
+      $groups[] = [
+        'id' => $task_id,
+        'label' => $label,
+        'variables' => [],
+        'prompts' => $prompts,
+      ];
+    }
+    return $groups;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getSuggestions(array $ids, ?string $entityType, ?string $bundle, CacheableMetadata $cacheability): array {
+    $ids = array_values(array_filter(array_map('strval', $ids)));
+    if (!$ids) {
+      return [];
+    }
+    $prompts = $this->entityTypeManager->getStorage('ai_prompt_content')->loadMultiple($ids);
+
+    $suggestions = [];
+    foreach ($ids as $id) {
+      $prompt = $prompts[$id] ?? NULL;
+      if (!$prompt instanceof AIPrompt || !$prompt->isPublished()) {
+        continue;
+      }
+      if (!$this->matchesContext($prompt, $entityType, $bundle)) {
+        continue;
+      }
+      $cacheability->addCacheableDependency($prompt);
+      $suggestions[] = [
+        'id' => (int) $prompt->id(),
+        'label' => (string) $prompt->label(),
+        'prompt' => (string) $prompt->get('prompt')->value,
+        'variables' => [],
+      ];
+    }
+    return $suggestions;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function resolvePrompt(string $id, array $values): string {
+    $prompt = $this->loadPublished($id);
+    if (!$prompt instanceof AIPrompt) {
+      throw new \InvalidArgumentException('Prompt not found or access denied.');
+    }
+    // Thunder prompts carry no variables, so there is nothing to substitute.
+    return (string) $prompt->get('prompt')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getStarterEntityTypeId(): string {
+    return 'ai_prompt_content';
+  }
+
+  /**
+   * Loads a single published prompt.
+   *
+   * @param string $id
+   *   The prompt id.
+   *
+   * @return \Drupal\thunder_ai_prompt_management\Entity\AIPrompt|null
+   *   The prompt, or NULL if it does not exist or is unpublished.
+   */
+  private function loadPublished(string $id): ?AIPrompt {
+    $storage = $this->entityTypeManager->getStorage('ai_prompt_content');
+    $prompt = $storage->load($id);
+    return $prompt instanceof AIPrompt && $prompt->isPublished() ? $prompt : NULL;
+  }
+
+  /**
+   * Published prompts, no view-permission check (unpublished is the only gate).
+   *
+   * @return \Drupal\thunder_ai_prompt_management\Entity\AIPrompt[]
+   *   The published prompts.
+   */
+  private function publishedPrompts(): array {
+    $storage = $this->entityTypeManager->getStorage('ai_prompt_content');
+    $ids = $storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('status', 1)
+      ->execute();
+    /** @var \Drupal\thunder_ai_prompt_management\Entity\AIPrompt[] $prompts */
+    $prompts = array_filter(
+      $storage->loadMultiple($ids),
+      static fn ($prompt): bool => $prompt instanceof AIPrompt,
+    );
+    return $prompts;
+  }
+
+  /**
+   * Whether a prompt applies to the given entity type/bundle.
+   *
+   * Empty context matches everything; otherwise "type.*" or "type.bundle".
+   *
+   * @param \Drupal\thunder_ai_prompt_management\Entity\AIPrompt $prompt
+   *   The prompt.
+   * @param string|null $entityType
+   *   The entity type, or NULL to skip filtering.
+   * @param string|null $bundle
+   *   The bundle, or NULL to skip filtering.
+   *
+   * @return bool
+   *   Whether the prompt applies.
+   */
+  private function matchesContext(AIPrompt $prompt, ?string $entityType, ?string $bundle): bool {
+    if ($entityType === NULL || $bundle === NULL) {
+      return TRUE;
+    }
+    $contexts = [];
+    foreach ($prompt->get('entity_context') as $item) {
+      $value = (string) $item->value;
+      if ($value !== '') {
+        $contexts[] = $value;
+      }
+    }
+    if (!$contexts) {
+      return TRUE;
+    }
+    return in_array($entityType . '.*', $contexts, TRUE)
+      || in_array($entityType . '.' . $bundle, $contexts, TRUE);
+  }
+
+}

--- a/modules/thunder_ai_prompt_management/src/ThunderPromptSource.php
+++ b/modules/thunder_ai_prompt_management/src/ThunderPromptSource.php
@@ -179,7 +179,7 @@ final class ThunderPromptSource implements PromptSourceInterface {
     }
     $contexts = [];
     foreach ($prompt->get('entity_context') as $item) {
-      $value = (string) $item->value;
+      $value = (string) $item->getValue()['value'];
       if ($value !== '') {
         $contexts[] = $value;
       }

--- a/modules/thunder_ai_prompt_management/tests/src/Kernel/ThunderPromptSourceTest.php
+++ b/modules/thunder_ai_prompt_management/tests/src/Kernel/ThunderPromptSourceTest.php
@@ -23,12 +23,17 @@ class ThunderPromptSourceTest extends KernelTestBase {
   protected static $modules = [
     'system',
     'user',
+    'field',
+    'text',
+    'filter',
+    'entity_test',
     'key',
     'file',
     'ai',
     'ai_test',
     'ai_assistant_api',
     'ai_chatbot_assistant_ui',
+    'entity_blueprint',
     'thunder_ai_prompt_management',
   ];
 

--- a/modules/thunder_ai_prompt_management/tests/src/Kernel/ThunderPromptSourceTest.php
+++ b/modules/thunder_ai_prompt_management/tests/src/Kernel/ThunderPromptSourceTest.php
@@ -115,7 +115,7 @@ class ThunderPromptSourceTest extends KernelTestBase {
   }
 
   /**
-   * getSlashGroups() adds the prompt's and its task's cache tags.
+   * GetSlashGroups() adds the prompt's and its task's cache tags.
    */
   public function testSlashGroupsCacheability(): void {
     $this->createTask('seo', 'SEO');

--- a/modules/thunder_ai_prompt_management/tests/src/Kernel/ThunderPromptSourceTest.php
+++ b/modules/thunder_ai_prompt_management/tests/src/Kernel/ThunderPromptSourceTest.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\thunder_ai_prompt_management\Kernel;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\thunder_ai_prompt_management\Entity\AIPrompt;
+use Drupal\thunder_ai_prompt_management\Entity\AiTask;
+use Drupal\thunder_ai_prompt_management\ThunderPromptSource;
+
+/**
+ * Tests the assistant UI prompt source backed by ai_prompt_content.
+ *
+ * @group Thunder
+ */
+class ThunderPromptSourceTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'key',
+    'file',
+    'ai',
+    'ai_test',
+    'ai_assistant_api',
+    'ai_chatbot_assistant_ui',
+    'thunder_ai_prompt_management',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('ai_prompt_content');
+    $this->installSchema('system', ['sequences']);
+    $this->installConfig(['system', 'user']);
+  }
+
+  /**
+   * The service provider swaps the assistant UI's prompt source for this one.
+   */
+  public function testServiceOverride(): void {
+    $this->assertInstanceOf(
+      ThunderPromptSource::class,
+      $this->container->get('ai_chatbot_assistant_ui.prompt_source'),
+    );
+  }
+
+  /**
+   * Prompts are grouped by their ai_task, with no variables.
+   */
+  public function testSlashGroupsGroupByTask(): void {
+    $this->createTask('seo', 'SEO');
+    $this->createPrompt('Meta description', 'Suggest a meta description.', 'seo');
+
+    $groups = $this->source()->getSlashGroups(NULL, NULL, new CacheableMetadata());
+    $this->assertCount(1, $groups);
+    $this->assertSame('seo', $groups[0]['id']);
+    $this->assertSame('SEO', $groups[0]['label']);
+    $this->assertSame([], $groups[0]['variables']);
+    $this->assertSame('Meta description', $groups[0]['prompts'][0]['label']);
+    $this->assertSame('Suggest a meta description.', $groups[0]['prompts'][0]['prompt']);
+  }
+
+  /**
+   * Prompts are filtered by the entity open in the edit form.
+   */
+  public function testSlashGroupsFilterByEntityContext(): void {
+    $this->createTask('seo', 'SEO');
+    $this->createPrompt('Article prompt', 'For articles.', 'seo', ['node.article']);
+    $this->createPrompt('Image prompt', 'For images.', 'seo', ['media.image']);
+
+    $article = $this->source()->getSlashGroups('node', 'article', new CacheableMetadata());
+    $this->assertCount(1, $article);
+    $this->assertCount(1, $article[0]['prompts']);
+    $this->assertSame('Article prompt', $article[0]['prompts'][0]['label']);
+
+    $image = $this->source()->getSlashGroups('media', 'image', new CacheableMetadata());
+    $this->assertSame('Image prompt', $image[0]['prompts'][0]['label']);
+
+    $this->assertSame([], $this->source()->getSlashGroups('node', 'page', new CacheableMetadata()));
+  }
+
+  /**
+   * A "type.*" entity_context value matches every bundle of that type.
+   */
+  public function testWildcardEntityContextMatchesEveryBundle(): void {
+    $this->createTask('seo', 'SEO');
+    $this->createPrompt('Any node', 'Works on any node bundle.', 'seo', ['node.*']);
+
+    $article = $this->source()->getSlashGroups('node', 'article', new CacheableMetadata());
+    $this->assertCount(1, $article[0]['prompts']);
+
+    $page = $this->source()->getSlashGroups('node', 'page', new CacheableMetadata());
+    $this->assertCount(1, $page[0]['prompts']);
+
+    $this->assertSame([], $this->source()->getSlashGroups('media', 'image', new CacheableMetadata()));
+  }
+
+  /**
+   * A prompt with no entity_context restriction matches every context.
+   */
+  public function testUnrestrictedPromptMatchesEveryContext(): void {
+    $this->createTask('seo', 'SEO');
+    $this->createPrompt('Any context', 'Works anywhere.', 'seo');
+
+    $this->assertCount(1, $this->source()->getSlashGroups('node', 'article', new CacheableMetadata()));
+  }
+
+  /**
+   * getSlashGroups() adds the prompt's and its task's cache tags.
+   */
+  public function testSlashGroupsCacheability(): void {
+    $this->createTask('seo', 'SEO');
+    $task = AiTask::load('seo');
+    $this->assertNotNull($task);
+    $prompt = $this->createPrompt('Meta description', 'Suggest a meta description.', 'seo');
+
+    $cacheability = new CacheableMetadata();
+    $this->source()->getSlashGroups(NULL, NULL, $cacheability);
+
+    $tags = $cacheability->getCacheTags();
+    foreach ($prompt->getCacheTags() as $tag) {
+      $this->assertContains($tag, $tags);
+    }
+    foreach ($task->getCacheTags() as $tag) {
+      $this->assertContains($tag, $tags);
+    }
+  }
+
+  /**
+   * Suggestions preserve the configured order and skip non-matching prompts.
+   */
+  public function testSuggestionsRespectOrderAndFilter(): void {
+    $this->createTask('seo', 'SEO');
+    $first = $this->createPrompt('First', 'One.', 'seo', ['node.article']);
+    $second = $this->createPrompt('Second', 'Two.', 'seo');
+    $this->createPrompt('Hidden', 'Hidden.', 'seo', ['media.image']);
+
+    $suggestions = $this->source()->getSuggestions(
+      [(string) $first->id(), (string) $second->id()],
+      'node',
+      'article',
+      new CacheableMetadata(),
+    );
+    $this->assertCount(2, $suggestions);
+    $this->assertSame('First', $suggestions[0]['label']);
+    $this->assertSame('Second', $suggestions[1]['label']);
+    $this->assertSame([], $suggestions[0]['variables']);
+  }
+
+  /**
+   * Unpublished prompts are never offered.
+   */
+  public function testUnpublishedPromptsAreExcluded(): void {
+    $this->createTask('seo', 'SEO');
+    $this->createPrompt('Draft', 'Draft prompt.', 'seo', [], FALSE);
+
+    $this->assertSame([], $this->source()->getSlashGroups(NULL, NULL, new CacheableMetadata()));
+  }
+
+  /**
+   * A prompt with no ai_task still appears, under a fallback group.
+   */
+  public function testPromptWithoutTaskIsGrouped(): void {
+    AIPrompt::create([
+      'label' => 'Untasked',
+      'prompt' => 'No task assigned.',
+      'model' => 'openai__gpt-4o',
+    ])->save();
+
+    $groups = $this->source()->getSlashGroups(NULL, NULL, new CacheableMetadata());
+    $this->assertCount(1, $groups);
+    $this->assertSame('_none', $groups[0]['id']);
+    $this->assertSame('Untasked', $groups[0]['prompts'][0]['label']);
+  }
+
+  /**
+   * ResolvePrompt returns the raw text - thunder prompts have no variables.
+   */
+  public function testResolvePrompt(): void {
+    $this->createTask('seo', 'SEO');
+    $prompt = $this->createPrompt('Meta', 'Suggest a meta description.', 'seo');
+
+    $this->assertSame(
+      'Suggest a meta description.',
+      $this->source()->resolvePrompt((string) $prompt->id(), []),
+    );
+  }
+
+  /**
+   * Instantiates the source against the container's entity type manager.
+   */
+  private function source(): ThunderPromptSource {
+    return new ThunderPromptSource($this->container->get('entity_type.manager'));
+  }
+
+  /**
+   * Creates an ai task config entity.
+   */
+  private function createTask(string $id, string $label): void {
+    AiTask::create([
+      'id' => $id,
+      'label' => $label,
+      'description' => '',
+    ])->save();
+  }
+
+  /**
+   * Creates an ai prompt.
+   */
+  private function createPrompt(string $label, string $prompt, string $task, array $context = [], bool $published = TRUE): AIPrompt {
+    $prompt = AIPrompt::create([
+      'label' => $label,
+      'prompt' => $prompt,
+      'ai_task' => $task,
+      'model' => 'openai__gpt-4o',
+      'entity_context' => $context,
+      'status' => $published,
+    ]);
+    $prompt->save();
+    return $prompt;
+  }
+
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,11 +11,6 @@ parameters:
 			path: modules/thunder_taxonomy/src/ThunderTermAccessControlHandler.php
 
 		-
-			message: "#^Class Drupal\\\\thunder_ai_prompt_management\\\\ThunderPromptSource implements unknown interface Drupal\\\\ai_chatbot_assistant_ui\\\\PromptSourceInterface\\.$#"
-			count: 1
-			path: modules/thunder_ai_prompt_management/src/ThunderPromptSource.php
-
-		-
 			message: "#^Access to an undefined property Drupal\\\\Core\\\\Extension\\\\Extension\\:\\:\\$requires\\.$#"
 			count: 1
 			path: src/Installer/Form/ModuleConfigureForm.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,6 +11,11 @@ parameters:
 			path: modules/thunder_taxonomy/src/ThunderTermAccessControlHandler.php
 
 		-
+			message: "#^Class Drupal\\\\thunder_ai_prompt_management\\\\ThunderPromptSource implements unknown interface Drupal\\\\ai_chatbot_assistant_ui\\\\PromptSourceInterface\\.$#"
+			count: 1
+			path: modules/thunder_ai_prompt_management/src/ThunderPromptSource.php
+
+		-
 			message: "#^Access to an undefined property Drupal\\\\Core\\\\Extension\\\\Extension\\:\\:\\$requires\\.$#"
 			count: 1
 			path: src/Installer/Form/ModuleConfigureForm.php


### PR DESCRIPTION
## Summary
- Implements `ai_chatbot_assistant_ui`'s `PromptSourceInterface` against `thunder_ai_prompt_management`'s `ai_prompt_content` entity, grouped by `ai_task` and filtered by the `entity_context` field (`type.bundle` / `type.*` values).
- Swapped in via `ThunderAiPromptManagementServiceProvider::alter()`, guarded by `hasDefinition()` so this module carries no hard dependency on the chatbot module.
- `getSlashGroups()`/`getSuggestions()` take a `CacheableMetadata` argument and add their own tags via `addCacheableDependency()`, matching the interface signature.

## Test plan
- [ ] `ThunderPromptSourceTest` (Kernel) passes
- [ ] Manual: enable both modules, confirm slash commands / starter prompts populate from `ai_prompt_content` entities in the chatbot UI

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>